### PR TITLE
Include license file in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include test_requirements.txt


### PR DESCRIPTION
The terms of the MIT license require the license text be included with all copies of the software.

Also include a testing-related file.